### PR TITLE
docs(security): reference the audit script by repo-relative path

### DIFF
--- a/src-tauri/SECURITY_EXCEPTIONS.md
+++ b/src-tauri/SECURITY_EXCEPTIONS.md
@@ -6,7 +6,7 @@ Current exceptions are limited to informational transitive advisories
 (`unmaintained` / `unsound`) that are pulled in by upstream cross-platform
 dependencies and are not presently actionable without major upstream changes.
 
-The exception list is codified in `/Users/d/Projects/ScreenshotAnnotate/scripts/cargo_audit.sh`.
+The exception list is codified in `scripts/cargo_audit.sh`.
 
 Review policy:
 - Re-run `cargo audit --json` after every Tauri dependency upgrade.


### PR DESCRIPTION
## What

Points the security-exceptions document at its audit script by repository-relative path
instead of by an absolute path into a specific developer's home directory.

## Why

The document tells a reader how to re-run the audit that produced the listed exceptions.
Written as an absolute path into one machine's home directory, that instruction is wrong
for every other reader and for any continuous integration runner, and it fails quietly:
documentation does not error, it just misleads. A repository-relative path resolves for
anyone who has cloned the repository.

The absolute form also disclosed a local account name in a public repository. The
relative form carries the same instruction without it.

## How

One line changed in `src-tauri/SECURITY_EXCEPTIONS.md`. The script it points at is
unchanged and lives at the same location; only the way the document refers to it changed.

## Testing

Confirmed the referenced script exists at the repository-relative path now given, and
that this is the only line changed. Documentation only, so no code path is affected and
the suite was not re-run.

## Risk / Notes

Low risk, reversible in a single commit. This is a forward fix; the previous form remains
in published history and is not rewritten, since the exposure is an account name.
